### PR TITLE
new state api state_getKeys to expose storage keys

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -268,6 +268,12 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		&self.backend
 	}
 
+	/// Return storage entry keys in state in a block of given hash with given prefix.
+	pub fn storage_keys(&self, id: &BlockId<Block>, key_prefix: &StorageKey) -> error::Result<Vec<StorageKey>> {
+		let keys = self.state_at(id)?.keys(&key_prefix.0).into_iter().map(StorageKey).collect();
+		Ok(keys)
+	}
+
 	/// Return single storage entry of contract under given address in state in a block of given hash.
 	pub fn storage(&self, id: &BlockId<Block>, key: &StorageKey) -> error::Result<Option<StorageData>> {
 		Ok(self.state_at(id)?

--- a/core/client/src/light/backend.rs
+++ b/core/client/src/light/backend.rs
@@ -267,6 +267,11 @@ where
 		Vec::new()
 	}
 
+	fn keys(&self, _prefix: &Vec<u8>) -> Vec<Vec<u8>> {
+		// whole state is not available on light node
+		Vec::new()
+	}
+
 	fn try_into_trie_backend(self) -> Option<TrieBackend<Self::TrieBackendStorage, H>> {
 		None
 	}

--- a/core/rpc/src/state/mod.rs
+++ b/core/rpc/src/state/mod.rs
@@ -51,6 +51,10 @@ build_rpc_trait! {
 		#[rpc(name = "state_call", alias = ["state_callAt", ])]
 		fn call(&self, String, Bytes, Trailing<Hash>) -> Result<Bytes>;
 
+		/// Returns the keys with prefix, leave empty to get all the keys
+		#[rpc(name = "state_getKeys")]
+		fn storage_keys(&self, StorageKey, Trailing<Hash>) -> Result<Vec<StorageKey>>;
+
 		/// Returns a storage entry at a specific block's state.
 		#[rpc(name = "state_getStorage", alias = ["state_getStorageAt", ])]
 		fn storage(&self, StorageKey, Trailing<Hash>) -> Result<Option<StorageData>>;
@@ -133,6 +137,12 @@ impl<B, E, Block, RA> StateApi<Block::Hash> for State<B, E, Block, RA> where
 			)?
 			.return_data;
 		Ok(Bytes(return_data))
+	}
+
+	fn storage_keys(&self, key_prefix: StorageKey, block: Trailing<Block::Hash>) -> Result<Vec<StorageKey>> {
+		let block = self.unwrap_or_best(block)?;
+		trace!(target: "rpc", "Querying storage keys at {:?}", block);
+		Ok(self.client.storage_keys(&BlockId::Hash(block), &key_prefix)?)
 	}
 
 	fn storage(&self, key: StorageKey, block: Trailing<Block::Hash>) -> Result<Option<StorageData>> {

--- a/core/state-machine/src/backend.rs
+++ b/core/state-machine/src/backend.rs
@@ -81,6 +81,9 @@ pub trait Backend<H: Hasher> {
 	/// Get all key/value pairs into a Vec.
 	fn pairs(&self) -> Vec<(Vec<u8>, Vec<u8>)>;
 
+	/// Get all keys with given prefix
+	fn keys(&self, prefix: &Vec<u8>) -> Vec<Vec<u8>>;
+
 	/// Try convert into trie backend.
 	fn try_into_trie_backend(self) -> Option<TrieBackend<Self::TrieBackendStorage, H>>;
 }
@@ -276,6 +279,13 @@ impl<H: Hasher> Backend<H> for InMemory<H> where H::Out: HeapSizeOf {
 
 	fn pairs(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
 		self.inner.get(&None).into_iter().flat_map(|map| map.iter().map(|(k, v)| (k.clone(), v.clone()))).collect()
+	}
+
+	fn keys(&self, prefix: &Vec<u8>) -> Vec<Vec<u8>> {
+		self.inner.get(&None).into_iter().flat_map(|map| map.keys().filter_map(|k| match k.starts_with(prefix) {
+			true => Some(prefix.clone()),
+			false => None
+		})).collect()
 	}
 
 	fn try_into_trie_backend(self) -> Option<TrieBackend<Self::TrieBackendStorage, H>> {

--- a/core/state-machine/src/proving_backend.rs
+++ b/core/state-machine/src/proving_backend.rs
@@ -146,6 +146,10 @@ impl<'a, S, H> Backend<H> for ProvingBackend<'a, S, H>
 		self.backend.pairs()
 	}
 
+	fn keys(&self, prefix: &Vec<u8>) -> Vec<Vec<u8>> {
+		self.backend.keys(prefix)
+	}
+
 	fn storage_root<I>(&self, delta: I) -> (H::Out, MemoryDB<H>)
 		where I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>
 	{

--- a/core/state-machine/src/trie_backend.rs
+++ b/core/state-machine/src/trie_backend.rs
@@ -105,6 +105,32 @@ impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
 		}
 	}
 
+	fn keys(&self, prefix: &Vec<u8>) -> Vec<Vec<u8>> {
+		let mut read_overlay = MemoryDB::default();	// TODO: use new for correctness
+		let eph = Ephemeral::new(self.essence.backend_storage(), &mut read_overlay);
+
+		let collect_all = || -> Result<_, Box<TrieError<H::Out>>> {
+			let trie = TrieDB::<H>::new(&eph, self.essence.root())?;
+			let mut v = Vec::new();
+			for x in trie.iter()? {
+				let (key, _) = x?;
+				if key.starts_with(prefix) {
+					v.push(key.to_vec());
+				}
+			}
+
+			Ok(v)
+		};
+
+		match collect_all() {
+			Ok(v) => v,
+			Err(e) => {
+				debug!(target: "trie", "Error extracting trie values: {}", e);
+				Vec::new()
+			}
+		}
+	}
+
 	fn storage_root<I>(&self, delta: I) -> (H::Out, MemoryDB<H>)
 		where I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>
 	{


### PR DESCRIPTION
get all keys:
`curl -H 'Content-Type: application/json' -d '{ "jsonrpc": "2.0", "method":"state_getKeys", "params":["0x"], "id": 1 }' http://127.0.0.1:9933/`
get keys with `0d` prefix:
`curl -H 'Content-Type: application/json' -d '{ "jsonrpc": "2.0", "method":"state_getKeys", "params":["0x0d"], "id": 1 }' http://127.0.0.1:9933/`